### PR TITLE
[quickstart][bugfix] modify pom for quickstart and fix CONF_DIR bug:

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+wrapperUrl=https://maven.aliyun.com/repository/public/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/jax-tool/pom.xml
+++ b/jax-tool/pom.xml
@@ -110,7 +110,7 @@
                         </goals>
                         <configuration>
                             <!-- 生产压缩包名称 -->
-                            <finalName>jax-tool-${project.version}-${maven.build.timestamp}</finalName>
+                            <finalName>jax-tool-${project.version}-all</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <!-- assembly配置文件 -->
                             <descriptors>

--- a/jax-tool/release/release-assembly.xml
+++ b/jax-tool/release/release-assembly.xml
@@ -16,6 +16,7 @@
             <includes>
                 <include>jax-tool.sh</include>
             </includes>
+            <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/target</directory>

--- a/jax-web/pom.xml
+++ b/jax-web/pom.xml
@@ -200,7 +200,7 @@
                         </goals>
                         <configuration>
                             <!-- 生产压缩包名称 -->
-                            <finalName>jax-${project.version}-${maven.build.timestamp}</finalName>
+                            <finalName>jax-${project.version}-all</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <!-- assembly配置文件 -->
                             <descriptors>
@@ -212,4 +212,52 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--skip check of license ,style, javadoc for fast compile -->
+        <profile>
+            <id>dev_skip</id>
+            <activation>
+                <property>
+                    <name>dev_skip</name>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.mycila</groupId>
+                            <artifactId>license-maven-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-checkstyle-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jax-web/release/release-assembly.xml
+++ b/jax-web/release/release-assembly.xml
@@ -18,6 +18,7 @@
                 <include>start-docker.sh</include>
                 <include>stop.sh</include>
             </includes>
+            <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/release</directory>
@@ -56,6 +57,11 @@
         </fileSet>
     </fileSets>
     <files>
+        <file>
+            <source>${project.basedir}/src/main/resources/application.yml</source>
+            <outputDirectory>jax/jax/</outputDirectory>
+            <destName>application.yml</destName>
+        </file>
         <file>
             <source>${project.basedir}/src/main/resources/application.yml</source>
             <outputDirectory>jax/jax/</outputDirectory>

--- a/jax-web/release/start.sh
+++ b/jax-web/release/start.sh
@@ -20,4 +20,15 @@ LibDir=${JAX_HOME}/jax/lib
 
 JAX_JAVA_OPTS="-Xmx1024m -Xms1024m"
 
+# Set Debug options if enabled
+if [ "x$JAX_WEB_DEBUG_PORT" != "x" ]; then
+    # Use the defaults if JAVA_DEBUG_OPTS was not set
+    DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$JAX_WEB_DEBUG_PORT"
+    if [ -z "$JAVA_DEBUG_OPTS" ]; then
+        JAVA_DEBUG_OPTS="$DEFAULT_JAVA_DEBUG_OPTS"
+    fi
+	echo "Enabling Java debug options: $JAVA_DEBUG_OPTS"
+    JAX_JAVA_OPTS="$JAVA_DEBUG_OPTS $JAX_JAVA_OPTS"
+fi
+
 exec "$JAVA" -Dloader.path=${LibDir} -jar $JAX_JAVA_OPTS -Dspring.config.location=${ConfigLocation} -Dlogging.config=${LoggingConfig} ${ProgramJar} "$@" <&- &

--- a/jax-web/src/main/java/com/eoi/jax/web/common/config/AppConfig.java
+++ b/jax-web/src/main/java/com/eoi/jax/web/common/config/AppConfig.java
@@ -28,7 +28,7 @@ public class AppConfig {
     public static final String JAX_JOB_JAR_LIB = "jaxjobjarlib";
     public static final String JAX_JOB_WORK_DIR = "jaxjobworkdir";
     public static final String JAX_JOB_PYTHON_DIR = "jaxjobpythondir";
-    public static final String HADOOP_ETC_RELATIVE = "etc";
+    public static final String HADOOP_ETC_RELATIVE = "etc/hadoop";
     public static final String HADOOP_YARN_BIN_RELATIVE = "bin/yarn";
     public static final String FLINK_BIN_RELATIVE = "bin/flink";
     public static final String SPARK_BIN_RELATIVE = "bin/spark-submit";

--- a/jax-web/src/main/java/com/eoi/jax/web/provider/cluster/ClusterFlinkOpts.java
+++ b/jax-web/src/main/java/com/eoi/jax/web/provider/cluster/ClusterFlinkOpts.java
@@ -22,6 +22,9 @@ import com.eoi.jax.web.dao.entity.TbCluster;
 import com.eoi.jax.web.dao.entity.TbOptsFlink;
 import org.springframework.beans.BeanUtils;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -306,6 +309,17 @@ public class ClusterFlinkOpts {
 
     public String getLib() {
         return ClusterVariable.genFlinkLib(getHome());
+    }
+
+    public String getDefaultConfDir() {
+        Path flinkConfInstall = Paths.get(getHome(), "conf");
+        if (!Files.exists(flinkConfInstall)) {
+            String flinkConfDirVal = System.getenv("FLINK_CONF_DIR");
+            if (null != flinkConfDirVal && !flinkConfDirVal.isEmpty()) {
+                flinkConfInstall = Paths.get(flinkConfDirVal);
+            }
+        }
+        return flinkConfInstall.toString();
     }
 
     public ClusterFlinkOpts withDefault() {


### PR DESCRIPTION
### What is the purpose of the change
 to quick start for new user and fix CONF_DIR bug for window-os-developers; 

### Brief change log
 - maven-wrapper.properties中替换成aliyun镜像,加速初始化maven/wrapper下载
 - 父pom中把finalName的${maven.build.timestamp}改为all以解决window无法识别文件名而编译失败问题
 - 增加1个dev_skip profile可选择跳过 license,checkstyle,enforcer,javadoc插件,用于子模块独立编译
 - modify jax-tool:pom finalName ${maven.build.timestamp} as all for Window compile
 - add DEBUG_PORT and runnable application.yml for quick start
 - add env:$FLINK_CONF_DIR when getFlinkProcessRunner(), 否则可能读取环境中其他版本的CONF_DIR导致 无法输出yarnAppId日志而卡在Start状态;
 - AppConfig.HADOOP_ETC_RELATIVE 从"etc" -> "etc/hadoop" 才能正确读取 hadoop基础配置文件;


### Does this pull request potentially affect one of the following parts:
 Dependencies (does it add or upgrade a dependency): no
 The public API, i.e., is any changed class annotated with @Public(Evolving): no
 The serializers: no
 The runtime per-record code paths (performance sensitive): no
 Anything that affects deployment or recovery: no


### Documentation
 Does this pull request introduce a new feature? no
 If yes, how is the feature documented? not applicable
